### PR TITLE
add custom heading component

### DIFF
--- a/src/column-definition.js
+++ b/src/column-definition.js
@@ -24,6 +24,8 @@ ColumnDefinition.PropTypes = {
   displayName: React.PropTypes.string,
   //The component that should be rendered instead of the standard column data. This component will still be rendered inside of a TD element.
   customComponent: React.PropTypes.object,
+  //The component that should be rendered instead of the standard column header. This component will still be rendered inside of a TH element.
+  customHeadingComponent: React.PropTypes.object,
   //Can this column be sorted
   sortable: React.PropTypes.bool,
   //What sort type this column uses - magic string :shame:

--- a/src/table-heading-cell.js
+++ b/src/table-heading-cell.js
@@ -43,7 +43,7 @@ class TableHeadingCell extends React.Component {
 
     const { className } = getStyleProperties(this.props, 'tableHeadingCell');
     const classNames = classnames(className, this.props.columnProperty ? this.props.columnProperty.headerCssClassName : null)
-    const { sorted } = this.props;
+    const { sorted, state, title, sortAscending } = this.props;
     const clickEvent = this.isSortable() ? this._handleClick : null;
 
     return (
@@ -54,8 +54,16 @@ class TableHeadingCell extends React.Component {
         onClick={clickEvent}
         className={classNames}
       >
-        {this.props.title} { this.getSortIcon() }
-      </th>);
+        {this.props.hasOwnProperty('customHeadingComponent') ?
+          <this.props.customHeadingComponent
+            state={state}
+            title={title}
+            sorted={sorted}
+            sortAscending={sortAscending}
+            sortIcon={this.getSortIcon()} /> :
+          [this.props.title, this.getSortIcon()]}
+      </th>
+    );
   }
 
   _handleHover() {


### PR DESCRIPTION
Related to #13.

I added one `customHeadingComponent` prop in the `ColumnDefinition`.
When a component is defined in this `customHeadingComponent` prop, it will be rendered instead of the default title + sortIcon.
eg:

```
class Header extends Component {

  render() {
    return (
      <span>Custom {this.props.title} {this.props.sortIcon}</span>
    );
  }
}

export default class App extends Component {

  render() {

    return (
      <Griddle data={fakeData}>
        <RowDefinition>
          <ColumnDefinition id="name" customHeadingComponent={Header} />
          <ColumnDefinition id="city" />
        </RowDefinition>
      </Griddle>
    );
  }
}
```

I kept the customHeadingComponent propType as an object, like the customComponent.
But shouldn't it be an element?

Great component btw. I've been using a lot.
