### PR TITLE
Filter by column

### DIFF
--- a/src/column-definition.js
+++ b/src/column-definition.js
@@ -24,6 +24,8 @@ ColumnDefinition.PropTypes = {
   displayName: React.PropTypes.string,
   //The component that should be rendered instead of the standard column data. This component will still be rendered inside of a TD element.
   customComponent: React.PropTypes.object,
+  //The component that should be used instead of the normal title
+  customHeaderComponent: React.PropTypes.object,
   //Can this column be sorted
   sortable: React.PropTypes.bool,
   //What sort type this column uses - magic string :shame:

--- a/src/griddle.js
+++ b/src/griddle.js
@@ -27,6 +27,7 @@ export default class Griddle extends React.Component {
       getPreviousPage: this._previousPage,
       getPage: this._getPage,
       setFilter: this._filter,
+      setFilterByColumn: this._filterByColumn,
       setPageSize: this._setPageSize,
       rowHover: this._rowHover,
       rowClick: this._rowClick,
@@ -92,6 +93,12 @@ export default class Griddle extends React.Component {
   _filter = (query) => {
     if(this.props.filterData) {
       this.props.filterData(query);
+    }
+  }
+
+  _filterByColumn = (filter, column) => {
+    if(this.props.filterDataByColumn) {
+      this.props.filterDataByColumn(filter, column)
     }
   }
 

--- a/src/griddle.js
+++ b/src/griddle.js
@@ -51,6 +51,7 @@ export default class Griddle extends React.Component {
     const events = this.getEvents();
     const components = this.getComponents();
     const { styles, settings } = this;
+
     return (
       <div>
         {/*TODO: Lets not duplicate these prop defs all over (events/components) */}
@@ -58,7 +59,7 @@ export default class Griddle extends React.Component {
         <this.components.SettingsToggle components={components} styles={styles} events={events} settings={settings} showSettings={this._showSettings} />
         {this.state.showSettings ? <this.components.Settings {...this.props} components={components} styles={styles} settings={settings} events={events} /> : null }
 
-        {this.props.data && this.props.data.length > 0 ?
+        {(this.props.data && this.props.data.length > 0) || this.props.columnFilters.length > 0 ?
           <this.components.Table {...this.props} components={components} styles={styles} settings={settings} events={events} /> :
           <this.components.NoResults components={components} styles={styles} settings={settings} events={events} /> }
 

--- a/src/table-heading-cell.js
+++ b/src/table-heading-cell.js
@@ -54,7 +54,7 @@ class TableHeadingCell extends React.Component {
         onClick={clickEvent}
         className={classNames}
       >
-        {this.props.title} { this.getSortIcon() }
+        {this.props.customHeaderComponent ? <this.props.customHeaderComponent {...this.props} /> : this.props.title } { this.getSortIcon() }
       </th>);
   }
 

--- a/src/table.js
+++ b/src/table.js
@@ -9,6 +9,61 @@ class Table extends React.Component {
     this.state = {};
   }
 
+  getTableBodySection() {
+    if(this.props.data.length < 1) {
+      return (
+        <tbody>
+          <tr>
+            <td>
+              <this.props.components.NoResults
+                components={this.props.components}
+                styles={this.props.styles}
+                settings={this.props.settings}
+                events={this.props.events} />
+            </td>
+          </tr>
+        </tbody>
+      );
+    }
+
+    return <this.props.components.TableBody {...this.props} />;
+  }
+
+  getColumns() {
+    const columnProperties = this.props.renderProperties.columnProperties;
+
+    if(this.props.data.length > 0) {
+      return Object.keys(this.props.data[0]);
+    }
+
+    if(columnProperties) {
+      return Object.keys(this.props.renderProperties.columnProperties).sort((first, second) => {
+        const firstColumn = columnProperties[first];
+        const secondColumn = columnProperties[second];
+
+        //deal with columns without order properties
+        if(!firstColumn['order'] && !secondColumn['order']) { return 0; }
+        if(firstColumn['order'] && !secondColumn['order']) { return -1 }
+        if(!firstColumn['order'] && secondColumn['order']) { return 1 }
+
+        //order the columns if they both have an order property
+        return (firstColumn["order"]) - (secondColumn["order"]);
+      });
+    }
+
+    return [];
+  }
+
+  getTableHeaderSection() {
+    const columns = this.getColumns();
+
+    if(columns.length > 0) {
+      return <this.props.components.TableHeading columns={columns} {...this.props} />
+    }
+
+    return null;
+  }
+
   render() {
     const { settings, styles } = this.props;
     const style = styles.getStyle({
@@ -22,16 +77,15 @@ class Table extends React.Component {
 
     const { className } = getStyleProperties(this.props, 'table');
     //translate the definition object to props for Heading / Body
-    return this.props.data.length > 0 ?
-      (
-        <table
-          className={className}
-          style={style}
-        >
-          <this.props.components.TableHeading columns={Object.keys(this.props.data[0])} {...this.props} />
-          <this.props.components.TableBody {...this.props} />
-        </table>
-      ) : null;
+    return (
+      <table
+        className={className}
+        style={style}
+      >
+        { this.getTableHeaderSection() }
+        { this.getTableBodySection() }
+      </table>
+    );
   }
 }
 


### PR DESCRIPTION
The move to selectors will help clean a lot of this up. Had to check for data + columnFilters in griddle (since if you added a column filter that didn't have data -- it'd show the no results without a way to unfilter).

The new selector PR will allow for getting the columns aside from data and we can just check against columns instead of checking for data or something along those lines.

This is also does way more operations than the views should. The selectors PR for griddle-render is working toward making the views know much much less. Keep that in mind when adding this to the selectors PR.
